### PR TITLE
Async profiler helper script

### DIFF
--- a/asyncProfilerLauncher.sh
+++ b/asyncProfilerLauncher.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [[ -z $1 || -z $2 ]]
+then
+	echo "Need to enter the type and the seconds as arguments like 'asyncprofilerlauncher.sh alloc 60'. Types are whatever is supported by async profiler like 'cpu' and 'alloc'"
+	exit 1
+fi	
+
+type=$1
+seconds=$2
+format=${3:-html}
+timestamp=$(date +%Y%m%d%H%M%S)
+pid=$(pgrep java)
+
+sudo -u hbase /opt/async-profiler/profiler.sh -e $type -d $seconds -o $format -f /tmp/async-profiler-$type-out-$timestamp\.$format $pid


### PR DESCRIPTION
Helper for running [Async Profiler](https://github.com/jvm-profiling-tools/async-profiler)

Pass in the profiler type and the time to run the profiling and it will generate a timestamped and type named html file in tmp (or different file format if specified).

usage: `asyncProfilerLauncher.sh cpu 60` or `asyncProfilerLauncher.sh alloc 120 svg`
Profiling type/event is required, see https://github.com/jvm-profiling-tools/async-profiler#profiler-options
Seconds to profile is required
Format to use defaults to html but can set it to svg